### PR TITLE
Package sitewide context for digital header block.

### DIFF
--- a/modules/custom/utk_banner/utk_banner.context.inc
+++ b/modules/custom/utk_banner/utk_banner.context.inc
@@ -54,5 +54,43 @@ function utk_banner_context_default_contexts() {
   t('utk_frontend');
   $export['utk_banner'] = $context;
 
+  $context = new stdClass();
+  $context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+  $context->api_version = 3;
+  $context->name = 'utk_digital_header';
+  $context->description = '';
+  $context->tag = 'utk_frontend';
+  $context->conditions = array(
+    'sitewide' => array(
+      'values' => array(
+        1 => 1,
+      ),
+    ),
+  );
+  $context->reactions = array(
+    'block' => array(
+      'blocks' => array(
+        'utk_lib_digital_custom-utk_lib_digital_custom_header' => array(
+          'module' => 'utk_lib_digital_custom',
+          'delta' => 'utk_lib_digital_custom_header',
+          'region' => 'utk_header',
+          'weight' => '-10',
+        ),
+        'block-3' => array(
+          'module' => 'block',
+          'delta' => '3',
+          'region' => 'utk_header',
+          'weight' => '-9',
+        ),
+      ),
+    ),
+  );
+  $context->condition_mode = 1;
+
+  // Translatables
+  // Included for use with string extractors like potx.
+  t('utk_frontend');
+  $export['utk_digital_header'] = $context;
+
   return $export;
 }

--- a/modules/custom/utk_banner/utk_banner.info
+++ b/modules/custom/utk_banner/utk_banner.info
@@ -1,11 +1,14 @@
 name = UTK Banner
 core = 7.x
 package = UTK Islandora
+dependencies[] = block
 dependencies[] = context
 dependencies[] = ctools
 dependencies[] = features
+dependencies[] = text
 dependencies[] = utk_lib_digital_custom
 features[context][] = utk_banner
+features[context][] = utk_digital_header
 features[ctools][] = context:context:3
 features[features_api][] = api:2
 features[field_base][] = body


### PR DESCRIPTION
**What does this do?**

Adds context that sets the delta of utk_lib_digital_custom_header to be enabled in the utk_header region sitewide. This is packaged in the feature **utk_banner**.

**How to test?**

Tough to test as there is another bug that could inhibit it.

Make sure the block **utk_lib_digital_custom_header** is disabled in block configuration, with no region set.

- `git pull`
- `git checkout context_header`
- `cd $DRUPAL_HOME` or however you get to your drupal root
- `drush fl`
- `drush fr utk_banner`
- `drush cc drush`
- `drush cc all`

The block should now be rendering on ANY path where the newly created banner block also does render. 

**Additional notes**

Eventually the header block will render on every page. Note that this is currently a separate bug detailed here: https://jirautk.atlassian.net/browse/DIGITAL-826