### PR TITLE
Context header

### DIFF
--- a/modules/custom/utk_header/utk_header.context.inc
+++ b/modules/custom/utk_header/utk_header.context.inc
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @file
+ * utk_header.context.inc
+ */
+
+/**
+ * Implements hook_context_default_contexts().
+ */
+function utk_header_context_default_contexts() {
+  $export = array();
+
+  $context = new stdClass();
+  $context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+  $context->api_version = 3;
+  $context->name = 'utk_header';
+  $context->description = '';
+  $context->tag = 'utk_frontend';
+  $context->conditions = array(
+    'sitewide' => array(
+      'values' => array(
+        1 => 1,
+      ),
+    ),
+  );
+  $context->reactions = array(
+    'block' => array(
+      'blocks' => array(
+        'utk_lib_digital_custom-utk_lib_digital_custom_header' => array(
+          'module' => 'utk_lib_digital_custom',
+          'delta' => 'utk_lib_digital_custom_header',
+          'region' => 'utk_header',
+          'weight' => '-10',
+        ),
+      ),
+    ),
+  );
+  $context->condition_mode = 0;
+
+  // Translatables
+  // Included for use with string extractors like potx.
+  t('utk_frontend');
+  $export['utk_header'] = $context;
+
+  return $export;
+}

--- a/modules/custom/utk_header/utk_header.features.inc
+++ b/modules/custom/utk_header/utk_header.features.inc
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * utk_header.features.inc
+ */
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function utk_header_ctools_plugin_api($module = NULL, $api = NULL) {
+  if ($module == "context" && $api == "context") {
+    return array("version" => "3");
+  }
+}

--- a/modules/custom/utk_header/utk_header.info
+++ b/modules/custom/utk_header/utk_header.info
@@ -1,0 +1,9 @@
+name = UTK Header
+core = 7.x
+package = UTK Islandora
+dependencies[] = context
+dependencies[] = ctools
+dependencies[] = utk_lib_digital_custom
+features[context][] = utk_header
+features[ctools][] = context:context:3
+features[features_api][] = api:2

--- a/modules/custom/utk_header/utk_header.module
+++ b/modules/custom/utk_header/utk_header.module
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Code for the UTK Header feature.
+ */
+
+include_once 'utk_header.features.inc';

--- a/modules/utk_lib_digital_custom/utk_lib_digital_custom.module
+++ b/modules/utk_lib_digital_custom/utk_lib_digital_custom.module
@@ -51,21 +51,22 @@ function utk_lib_digital_custom_block_view($delta = '')
         $object = islandora_object_load($pid);
         $member_of = utk_lib_digital_custom_parent($pid);
     }
-      // firing the 2 blocks
-      switch ($delta) {
-      case 'utk_lib_digital_custom_header':
-          $block['content'] = utk_lib_digital_custom_header($member_of);
-          break;
-      case 'utk_lib_digital_custom_banner':
-          if ($member_of != "") {
-            $block['content'] = utk_lib_digital_custom_banner($member_of);
-          }
-          break;
+
+    // firing the 2 blocks
+    switch ($delta) {
+        case 'utk_lib_digital_custom_header':
+            $block['content'] = utk_lib_digital_custom_header();
+            break;
+        case 'utk_lib_digital_custom_banner':
+            if ($member_of != "") {
+                $block['content'] = utk_lib_digital_custom_banner($member_of);
+            }
+            break;
     }
     return $block;
 }
 
-function utk_lib_digital_custom_header($pidd)
+function utk_lib_digital_custom_header()
 {
     return '
             <div class="utk-lib-digital--header">
@@ -73,7 +74,7 @@ function utk_lib_digital_custom_header($pidd)
                   <div class="container">
                       <a class="utk-lib-digital--header--title"
                          href="https://digital.lib.utk.edu">
-                        <h1>' . variable_get('site_name', 'Default'). '</h1>
+                        <h1>' . variable_get('site_name', 'Default') . '</h1>
                       </a>
                       <ul class="utk-lib-digital--header--menu">
                         <li><a href="https://digital.lib.utk.edu">Home</a></li>
@@ -97,19 +98,19 @@ function utk_lib_digital_custom_banner($pidd)
     //Postcards from the Great Smoky Mountains
 
     return '
-            <div class="utk-lib-digital--banner" id="utk-digital-banner-' . str_replace(':', '-', $pidd) .'">
+            <div class="utk-lib-digital--banner" id="utk-digital-banner-' . str_replace(':', '-', $pidd) . '">
                 <a href="/collections/islandora/object/' . $pidd . '">
                     <div class="utk-lib-digital--banner--inner">
                         <div class="utk-lib-digital--banner--info">
                             <span class="utk-lib-digital--banner--info--title">
                                 <strong>' . $title . '</strong>
                             </span>
-                            <span class="utk-lib-digital--banner--info--abstract">'  . $abstract . '</span>
+                            <span class="utk-lib-digital--banner--info--abstract">' . $abstract . '</span>
                         </div>
                         <img alt="' . $title . ' collection banner image" src="' . $image . '" />
                     </div>
                     <div class="utk-lib-digital--banner--background-wrap">
-                        <div class="utk-lib-digital--banner--background" style="background-image: url('. $image . ')"></div>
+                        <div class="utk-lib-digital--banner--background" style="background-image: url(' . $image . ')"></div>
                     </div>
                 </a>
             </div>
@@ -129,7 +130,7 @@ function utk_lib_digital_custom_featured_image($islandora_pid)
     $featured = json_decode($json);
     $alt = $featured->data->fgs_label_s;
     $src = 'https://digital.lib.utk.edu/iiif/2/collections~islandora~object~' . $islandora_pid . '~datastream~FEATURED~view/full/322,/0/default.jpg';
-    $output = '<img src="' . $src .'" alt="' . $alt .'" />';
+    $output = '<img src="' . $src . '" alt="' . $alt . '" />';
     return $output;
 }
 
@@ -139,9 +140,9 @@ function utk_lib_digital_custom_parent($pid_to_check)
     module_load_include('inc', 'islandora', 'includes/utilities');
     // Handle errors when fetching the JSON from WP site.
     set_error_handler(
-      function ($severity, $message, $file, $line) {
-          throw new ErrorException($message, $severity, $severity, $file, $line);
-      }
+        function ($severity, $message, $file, $line) {
+            throw new ErrorException($message, $severity, $severity, $file, $line);
+        }
     );
 
     $object_to_check = islandora_object_load($pid_to_check);
@@ -152,11 +153,11 @@ function utk_lib_digital_custom_parent($pid_to_check)
             $ismemberofcollection = $pid_to_check;
             $json = file_get_contents('https://www.lib.utk.edu/wp-json/dc/pid/' . $pid_to_check);
             $json_check = json_decode($json);
-            if ( json_decode($json) === null ) {
-               throw new Exception('JSON is empty');
+            if (json_decode($json) === null) {
+                throw new Exception('JSON is empty');
             }
             if (!isset($json_check->data->utk_fedora_datastream_version_FEATURED_SIZE_ms)) {
-               throw new Exception('JSON FEATURED is not set');
+                throw new Exception('JSON FEATURED is not set');
             }
 
         } catch (Exception $e) {
@@ -167,7 +168,7 @@ function utk_lib_digital_custom_parent($pid_to_check)
                 $ismemberofcollection = $object_to_check->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfCollection')[0]['object']['value'];
                 $ismemberofcollection = utk_lib_digital_custom_parent($ismemberofcollection);
             } else {
-              $ismemberofcollection = "";
+                $ismemberofcollection = "";
             }
             // For Debugging
             // echo $e->getMessage();

--- a/themes/sis/template.php
+++ b/themes/sis/template.php
@@ -26,7 +26,13 @@ function example_preprocess_html(&$variables) {
 */
 
 function sis_preprocess_html(&$variables) {
-    $variables['utk_header'] = block_get_blocks_by_region('utk_header');
+
+    // render blocks for region by context module or by structure/blocks as backup
+    if ($plugin = context_get_plugin('reaction', 'block')) :
+        $variables['utk_header'] = $plugin->block_get_blocks_by_region('utk_header');
+    else:
+        $variables['utk_header'] = block_get_blocks_by_region('utk_header');
+    endif;
 
     return $variables;
 }


### PR DESCRIPTION
**What does this do?**

Uses context and features modules to set the delta of **utk_lib_digital_custom_header** to be enabled in the _utk_header_ region sitewide and stores this configuration as code via a custom feature module. This is packaged in the feature _utk_header_.

**How to test?**

Make sure the block **utk_lib_digital_custom_header** is disabled in block configuration, with no region set. This is important, as we want to control this via our codebase.

```
git pull
git checkout context_header
```
```
vagrant ssh
cd /vhosts/digital/web/collections
drush fl
drush en utk_header # may already be enabled
drush fr utk_header  # may already match state
drush cc drush
drush cc all
```
The block should now be rendering on ANY path when the sis theme is enabled.

**Additional notes**

I also fixed an issue in the sis template.php to make a context compatible **block_get_blocks_by_region()** call. Additionally, I made some fairly trivial code on **utk_lib_digital_custom.module** reformatting for cleanliness reasons.