### PR TITLE
Apply Safeguard Hotfix - DIGITAL-837

### DIFF
--- a/modules/utk_lib_digital_custom/utk_lib_digital_custom.module
+++ b/modules/utk_lib_digital_custom/utk_lib_digital_custom.module
@@ -190,6 +190,8 @@ function utk_lib_digital_check_object_pid($this_object)
         $pid = $this_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfCollection')[0]['object']['value'];
     } else if (isset($this_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOf')[0])) {
         $pid = $this_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOf')[0]['object']['value'];
+    } else {
+        $pid = null;
     }
 
     return $pid;

--- a/modules/utk_lib_digital_custom/utk_lib_digital_custom.module
+++ b/modules/utk_lib_digital_custom/utk_lib_digital_custom.module
@@ -186,10 +186,19 @@ function utk_lib_digital_custom_parent($pid_to_check)
 function utk_lib_digital_check_object_pid($this_object)
 {
 
+    // basic images
     if (isset($this_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfCollection')[0])) {
         $pid = $this_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfCollection')[0]['object']['value'];
+
+    // book pages
     } else if (isset($this_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOf')[0])) {
         $pid = $this_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOf')[0]['object']['value'];
+
+    // compound objects
+    } else if (isset($this_object->relationships->get(FEDORA_RELS_EXT_URI, 'isConstituentOf')[0])) {
+        $pid = $this_object->relationships->get(FEDORA_RELS_EXT_URI, 'isConstituentOf')[0]['object']['value'];
+
+    // note explicitly noted
     } else {
         $pid = null;
     }


### PR DESCRIPTION
**What does this do?** See: https://jirautk.atlassian.net/browse/DIGITAL-837

**This is currently live.** We're working through the kinks of our workflow, and as such, this is a Hotfix that I pushed up and testing over the holiday weekend.

Late Friday evening (9/4), Louisa and Becky Becker noticed an issue on Digital. Work on Thursday to pull Digital into our Git workflow had pushed up code in the `utk_lib_digital_custom_parent()` that was causing a fatal error on Book pages, and Compound object items. I don't think this was anyone's particular fault, though more critical testing could have found this. We'll take this as a note and make sure that when doing development work related to finding data in arrays of our objects, we check all known content models and make implicit exceptions as failsafes.

The technical issue was that we were assuming that if we had an islandora object, we could get the PID only by **isMemberOfCollection**, when not all objects have this.

**How to test?**

As this is live, you can test directly on Porter or Digital. It will pass successfully if these pages can be reached without fataling.

We should now be able to see individual pages in books without issue.
https://digital.lib.utk.edu/collections/islandora/object/walden%3A620
https://digital.lib.utk.edu/collections/islandora/object/agrtfhs%3A2279
https://digital.lib.utk.edu/collections/islandora/object/alumnus%3A1507294769

**Additional notes**

Note lines 201-204 set the `$pid` to null if the relationship is not explicitly stated. This will protect us against fatals for this issue in the future, however, the consequence here is that that the banner will **not** render. If any additional content models are on known about in our repo, we should investigate and add their relationships to this conditional.