### PR TITLE
to drush-updates-20-12-03

### DIFF
--- a/modules/features/features.export.inc
+++ b/modules/features/features.export.inc
@@ -1033,9 +1033,6 @@ function features_set_signature($module, $component, $signature = NULL, $message
  * that were using a -dev branch after 7.x-2.11.
  * Since #3162854, it is stored in a dedicated non-cache table.
  *
- * @param bool $reset
- *   TRUE, to reset the static cache.
- *
  * @return string
  *   One of 'table', 'cache' or 'type'.
  *   On a fully updated database, this value will be 'table'.
@@ -1044,11 +1041,8 @@ function features_set_signature($module, $component, $signature = NULL, $message
  * @see \features_set_signature()
  * @see \features_update_7202()
  */
-function _features_get_signature_storage_type($reset = FALSE) {
-  static $type;
-  if ($reset) {
-    $type = NULL;
-  }
+function _features_get_signature_storage_type() {
+  $type = &drupal_static(__FUNCTION__);
   if ($type !== NULL) {
     return $type;
   }

--- a/modules/features/features.info
+++ b/modules/features/features.info
@@ -10,8 +10,8 @@ test_dependencies[] = views
 
 configure = admin/structure/features/settings
 
-; Information added by Drupal.org packaging script on 2020-11-01
-version = "7.x-2.12"
+; Information added by Drupal.org packaging script on 2020-11-20
+version = "7.x-2.13"
 core = "7.x"
 project = "features"
-datestamp = "1604202294"
+datestamp = "1605854056"

--- a/modules/features/features.install
+++ b/modules/features/features.install
@@ -17,13 +17,13 @@ function features_schema() {
       'module' => array(
         'description' => 'Name of the feature module.',
         'type' => 'varchar',
-        'length' => 255,
+        'length' => 64,
         'not null' => TRUE,
       ),
       'component' => array(
         'description' => 'Name of the features component.',
         'type' => 'varchar',
-        'length' => 255,
+        'length' => 128,
         'not null' => TRUE,
       ),
       'signature' => array(
@@ -76,6 +76,8 @@ function features_uninstall() {
   variable_del('features_ignored_orphans');
   variable_del('features_feature_locked');
   variable_del('features_lock_mode');
+  variable_del('features_update_7202_fixed_tmp');
+  variable_del('features_update_7202_possibly_broken');
 
   db_delete('variable')
     ->condition('name', 'features_admin_show_component_%', 'LIKE')
@@ -209,13 +211,13 @@ function features_update_7202() {
         'module' => array(
           'description' => 'Name of the feature module.',
           'type' => 'varchar',
-          'length' => 255,
+          'length' => 64,
           'not null' => TRUE,
         ),
         'component' => array(
           'description' => 'Name of the features component.',
           'type' => 'varchar',
-          'length' => 255,
+          'length' => 128,
           'not null' => TRUE,
         ),
         'signature' => array(
@@ -246,10 +248,10 @@ function features_update_7202() {
     db_create_table('features_signature', $schema);
   }
 
-
   // Load existing signatures.
-  if (db_table_exists('cache_features')) {
-    // The original version of the previous update has already run.
+  if (db_table_exists('cache_featurestate')) {
+    // The old version of features_update_7201() has run in the past, and a
+    // cache table was created to replace the 'features_codecache' variable.
     $cache = cache_get('features_codecache', 'cache_featurestate');
     $signaturess = !empty($cache->data)
       ? $cache->data
@@ -257,7 +259,8 @@ function features_update_7202() {
     $message = __FUNCTION__ . '() - from cache storage';
   }
   else {
-    // The update is from an earlier version of features.
+    // The current (inactive) version of features_update_7201() has run, and the
+    // 'features_codecache' variable still exists.
     $signaturess = variable_get('features_codecache', array());
     $message = __FUNCTION__ . '() - from variable storage';
   }
@@ -297,10 +300,57 @@ function features_update_7202() {
   // On failure, allow the exception to trickle up.
   $insert->execute();
 
+  // Set a temporary marker variable for subsequent updates.
+  // This variable was not set in an older version of this update.
+  variable_set('features_update_7202_fixed_tmp', TRUE);
+
   // Delete the old table and variable if the data migration was successful.
   variable_del('features_codecache');
 
   if (db_table_exists('cache_featurestate')) {
     db_drop_table('cache_featurestate');
+  }
+
+  // Reset the static cache that determines the storage type.
+  drupal_static_reset('_features_get_signature_storage_type');
+}
+
+/**
+ * Reduce varchar lengths in 'features_signature' table. See #3181858.
+ */
+function features_update_7203() {
+  // The following operations are only needed for sites that previously ran an
+  // older version of features_update_7202(). Trying to check this would
+  // probably be more copmlex, so we run it anyway.
+  db_change_field('features_signature', 'module', 'module', array(
+    'description' => 'Name of the feature module.',
+    'type' => 'varchar',
+    'length' => 64,
+    'not null' => TRUE,
+  ));
+  db_change_field('features_signature', 'component', 'component', array(
+    'description' => 'Name of the features component.',
+    'type' => 'varchar',
+    'length' => 128,
+    'not null' => TRUE,
+  ));
+}
+
+/**
+ * Set a marker variable, if the site could be affected by undesired reverts.
+ */
+function features_update_7204() {
+  if (variable_get('features_update_7202_fixed_tmp')) {
+    // The fixed version of features_update_7202() did run.
+    // Delete the temporary marker variable.
+    variable_del('features_update_7202_fixed_tmp');
+  }
+  else {
+    // Either the old broken version of features_update_7202() ran, or features
+    // was newly installed in a version where 7202 or 7203 was the latest
+    // update.
+    // Set a marker variable, indicating that some overridden features
+    // components might have been accidentally reverted. See #3183346.
+    variable_set('features_update_7202_possibly_broken', TRUE);
   }
 }

--- a/modules/features/tests/features_test/features_test.info
+++ b/modules/features/tests/features_test/features_test.info
@@ -21,8 +21,8 @@ features[user_permission][] = create features_test content
 features[views_view][] = features_test
 hidden = 1
 
-; Information added by Drupal.org packaging script on 2020-11-01
-version = "7.x-2.12"
+; Information added by Drupal.org packaging script on 2020-11-20
+version = "7.x-2.13"
 core = "7.x"
 project = "features"
-datestamp = "1604202294"
+datestamp = "1605854056"


### PR DESCRIPTION
the below drush updates are in this branch

[vagrant@islandora collections]$ drush pm-update
Update information last refreshed: Mon, 12/07/2020 - 14:51
 Name                 Installed Version  Proposed version  Message          
 Features (features)  7.x-2.12           7.x-2.13          Update available 


Code updates will be made to the following projects: Features [features-7.x-2.13]

Note: A backup of your project will be stored to backups directory if it is not managed by a supported version control system.
Note: If you have made any modifications to any file that belongs to one of these projects, you will have to migrate those modifications after updating.
Do you really want to continue with the update process? (y/n): y
Project features was updated successfully. Installed version is now 7.x-2.13.
Backups were saved into the directory                                                    [ok]
/home/vagrant/drush-backups/drupal7/20201207195115/modules/features.
 Features  7203  Reduce varchar lengths in 'features_signature' table. See #3181858.         
 Features  7204  Set a marker variable, if the site could be affected by undesired reverts.
Do you wish to run all pending updates? (y/n): y
Performed update: features_update_7203                                                   [ok]
Performed update: features_update_7204                                                   [ok]
'all' cache was cleared.                                                                 [success]
Finished performing updates.              