### PR TITLE
Find field_parent_pid on node and return for banner render.

### DIFF
--- a/modules/utk_lib_digital_custom/utk_lib_digital_custom.module
+++ b/modules/utk_lib_digital_custom/utk_lib_digital_custom.module
@@ -17,42 +17,29 @@ function utk_lib_digital_custom_block_info()
     return $blocks;
 }
 
-function utk_lib_digital_custom_block_view($delta = '')
-{
+function utk_lib_digital_custom_block_view($delta = '') {
+
     $block = array();
+
     module_load_include('inc', 'islandora', 'includes/utilities');
-    $arrowmont = array("curriculum", "arrpgimg", "arrscrap", "arrsimple", "sturley", "3d");
-    $gsmrc = array("roth", "50yrcove", "colloquy", "webster", "kintner", "adams", "pcard00", "smhc", "rfj", "thompson", "wcc", "wderfilms", "derris");
 
-    $is_a_introduction = drupal_match_path(drupal_lookup_path('alias', current_path()), '*collection');
     $parsed_request = explode('/', $_SERVER['REQUEST_URI']);
-
     $pid = check_plain(preg_replace("/\?.+/", "", urldecode(end($parsed_request))));
     $member_of = "";
-    // If not an introduction page determine the PID
-    if (!$is_a_introduction) {
+
+    if (arg(0) == 'node' && is_numeric(arg(1))) {
+        $node = node_load(arg(1));
+        if ($node->type == 'page') {
+            $field_parent_pid = field_get_items('node', $node, 'field_parent_pid');
+            $member_of = $field_parent_pid[0]['safe_value'];
+        }
+    } else {
         $object = islandora_object_load($pid);
-        // If an object find the parent
         if ($object) {
             $member_of = utk_lib_digital_custom_parent($pid);
         }
-    } else {
-        // Remove the collection string from mugwumpcollection to mugwump
-        $pid = str_replace("collection", "", $pid);
-
-        // Determined if collection belongs to naming exception collections
-        if (in_array($pid, $arrowmont)) {
-            $pid = "arrowmont:" . $pid;
-        } elseif (in_array($pid, $gsmrc)) {
-            $pid = "gsmrc:" . $pid;
-        } else {
-            $pid = "collections:" . $pid;
-        }
-        $object = islandora_object_load($pid);
-        $member_of = utk_lib_digital_custom_parent($pid);
     }
 
-    // firing the 2 blocks
     switch ($delta) {
         case 'utk_lib_digital_custom_header':
             $block['content'] = utk_lib_digital_custom_header();
@@ -63,6 +50,7 @@ function utk_lib_digital_custom_block_view($delta = '')
             }
             break;
     }
+
     return $block;
 }
 


### PR DESCRIPTION
**JIRA Issue**:  https://jirautk.atlassian.net/browse/DIGITAL-1042

What Does this Do?
==================

This small custom module change fixes an issue with our the logic that determines the collection object PID.

For more information, please see:
https://porter.lib.utk.edu/collections/wpa-tva

This page exists to demonstrate how the banner will now be rendered from the field_parent_pid on Drupal nodes where the node type is page. The field value must be set as the PID of the collection object where the abstract and FEATURED datastream are set. Previously the banner was derived through a flimsy mechanism that expected the path alias to match. This required hard coded logic to determine collection object PIDS for collections under arrowmont or gsmrc namespaces, and also made it difficult if a collection did not match the rigid pattern.

In this example, the Parent PID field is set as: wpatva:open

In the previous codebase, the path alias would have been expected to be: opencollection (https://porter.lib.utk.edu/collections/opencollection)

Usage guidelines
-----------------
- A collection can have a path of anything, or even no alias at all (node/200), as long as the Parent PID field is completed.
- If left empty, no banner will display.

How Should This Be Tested?
==========================

For speediness, this code has been deployed in a staging environment on Porter. 

To test, login there at https://porter.lib.utk.edu/collections/user/login?destination=node/add/page

1. Create any new node with node type _page_ (Basic Page)
2. Pick your favorite collection and add a collection PID to the **Parent PID** field
3. Save, and the banner for that collection will render


Additional Notes
================

Deploying this to production will require presetting the Parent PID on existing nodes where a banner is expected. If this approach is approved and merged, I'll move forward with that step and then deploy the code to digital/ale.