### PR TITLE
move parens on line 62 to make test work and stop error message

### DIFF
--- a/modules/islandora_social_metatags/islandora_social_metatags.module
+++ b/modules/islandora_social_metatags/islandora_social_metatags.module
@@ -59,7 +59,7 @@ function islandora_social_metatags_islandora_view_object() {
 
     //// Get Title.
     // If none available, exit.
-    if(count($title_objects > 1)) {
+    if(count($title_objects) > 1) {
       $title_pref = variable_get('islandora_social_metatags_compound_title', 'concatenate');
       // Remove parent or child as appropriate.
       switch($title_pref) {


### PR DESCRIPTION
this fixes the error coming from the islandora_social_metatags module.  The test on line 62 was failing because the tested value also included the expression after it.  The parens after the extression was supposed to be before the expression test.