### PR TITLE
Iiif badges

### DIFF
--- a/themes/sis/templates/islandora-audio.tpl.php
+++ b/themes/sis/templates/islandora-audio.tpl.php
@@ -10,6 +10,13 @@
 
 <div class="islandora-audio-object islandora" vocab="http://schema.org/" prefix="dcterms: http://purl.org/dc/terms/" typeof="AudioObject">
   <div class="islandora-audio-content-wrapper clearfix">
+    <div class="IIIF" style="display: block;">
+      <?php $transformed_pid = str_replace(":", "/", $islandora_object->id); ?>
+      <?php $assemble_uri = 'http://' . getenv('HTTP_HOST') . '/assemble/manifest/' . $transformed_pid . '?update=1'; ?>
+      <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
+      <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
+      <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
+    </div>
     <?php if (isset($islandora_content)): ?>
       <div class="islandora-audio-content">
         <?php if (isset($object['PROXY_MP3']) && !islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['PROXY_MP3'])): ?><p>This audio file is restricted to campus only.</p><?php endif; ?>

--- a/themes/sis/templates/islandora-audio.tpl.php
+++ b/themes/sis/templates/islandora-audio.tpl.php
@@ -13,9 +13,9 @@
     <div class="IIIF" style="display: block;">
       <?php $transformed_pid = str_replace(":", "/", $islandora_object->id); ?>
       <?php $assemble_uri = 'http://' . getenv('HTTP_HOST') . '/assemble/manifest/' . $transformed_pid . '?update=1'; ?>
-      <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
-      <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
-      <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
+      <?php print '<a href="' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
+      <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
+      <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
     </div>
     <?php if (isset($islandora_content)): ?>
       <div class="islandora-audio-content">

--- a/themes/sis/templates/islandora-basic-image.tpl.php
+++ b/themes/sis/templates/islandora-basic-image.tpl.php
@@ -13,9 +13,9 @@
         <div class="IIIF" style="display: block;">
             <?php $transformed_pid = str_replace(":", "/", $islandora_object->id); ?>
             <?php $assemble_uri = 'http://' . getenv('HTTP_HOST') . '/assemble/manifest/' . $transformed_pid . '?update=1'; ?>
-            <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
-            <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
-            <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
+            <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" target="_blank"/></a>'; ?>
+            <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
+            <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
         </div>
         <?php if (isset($islandora_content)): ?>
             <div class="islandora-basic-image-content">

--- a/themes/sis/templates/islandora-basic-image.tpl.php
+++ b/themes/sis/templates/islandora-basic-image.tpl.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * This is the template file for the object page for basic image
+ *
+ * @TODO: add documentation about file and available variables
+ */
+?>
+
+<div class="islandora-basic-image-object islandora" vocab="http://schema.org/" prefix="dcterms: http://purl.org/dc/terms/" typeof="ImageObject">
+    <div class="islandora-basic-image-content-wrapper clearfix">
+        <div class="IIIF" style="display: block;">
+            <?php $transformed_pid = str_replace(":", "/", $islandora_object->id); ?>
+            <?php $assemble_uri = 'http://' . getenv('HTTP_HOST') . '/assemble/manifest/' . $transformed_pid . '?update=1'; ?>
+            <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
+            <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
+            <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
+        </div>
+        <?php if (isset($islandora_content)): ?>
+            <div class="islandora-basic-image-content">
+                <?php print $islandora_content; ?>
+            </div>
+        <?php endif; ?>
+    </div>
+    <div class="islandora-basic-image-metadata">
+        <?php print $description; ?>
+        <?php if ($parent_collections): ?>
+            <div>
+                <h2><?php print t('In collections'); ?></h2>
+                <ul>
+                    <?php foreach ($parent_collections as $collection): ?>
+                        <li><?php print l($collection->label, "islandora/object/{$collection->id}"); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        <?php endif; ?>
+        <?php print $metadata; ?>
+    </div>
+</div>

--- a/themes/sis/templates/islandora-book-book.tpl.php
+++ b/themes/sis/templates/islandora-book-book.tpl.php
@@ -34,6 +34,11 @@
 
 <?php if(isset($viewer)): ?>
   <div id="book-viewer">
+      <?php $transformed_pid = str_replace(":", "/", $object->id); ?>
+      <?php $assemble_uri = 'http://' . getenv('HTTP_HOST') . '/assemble/manifest/' . $transformed_pid ; ?>
+      <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
+      <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
+      <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
     <?php print $viewer; ?>
   </div>
 <?php endif; ?>

--- a/themes/sis/templates/islandora-book-book.tpl.php
+++ b/themes/sis/templates/islandora-book-book.tpl.php
@@ -36,9 +36,9 @@
   <div id="book-viewer">
       <?php $transformed_pid = str_replace(":", "/", $object->id); ?>
       <?php $assemble_uri = 'http://' . getenv('HTTP_HOST') . '/assemble/manifest/' . $transformed_pid ; ?>
-      <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
-      <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
-      <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
+      <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" target="_blank"/></a>'; ?>
+      <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
+      <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
     <?php print $viewer; ?>
   </div>
 <?php endif; ?>

--- a/themes/sis/templates/islandora-large-image.tpl.php
+++ b/themes/sis/templates/islandora-large-image.tpl.php
@@ -25,9 +25,9 @@
   <div class="islandora-large-image-content-wrapper clearfix">
   <?php $transformed_pid = str_replace(":", "/", $islandora_object->id); ?>
   <?php $assemble_uri = 'http://' . getenv('HTTP_HOST') . '/assemble/manifest/' . $transformed_pid . '?update=1'; ?>
-  <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
-  <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
-  <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
+  <?php print '<a href="' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
+  <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
+  <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
    <?php if (!$islandora_content): ?>
       <?php if (!user_is_logged_in() && strpos(trim(parse_url(current_path())['path'], '/object/'), 'archivision', 1) !== 0): ?>
 	<p id='limited_access'>

--- a/themes/sis/templates/islandora-large-image.tpl.php
+++ b/themes/sis/templates/islandora-large-image.tpl.php
@@ -23,6 +23,11 @@
 ?>
 <div class="islandora-large-image-object islandora" vocab="http://schema.org/" prefix="dcterms: http://purl.org/dc/terms/" typeof="ImageObject">
   <div class="islandora-large-image-content-wrapper clearfix">
+  <?php $transformed_pid = str_replace(":", "/", $islandora_object->id); ?>
+  <?php $assemble_uri = 'http://' . getenv('HTTP_HOST') . '/assemble/manifest/' . $transformed_pid . '?update=1'; ?>
+  <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
+  <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
+  <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
    <?php if (!$islandora_content): ?>
       <?php if (!user_is_logged_in() && strpos(trim(parse_url(current_path())['path'], '/object/'), 'archivision', 1) !== 0): ?>
 	<p id='limited_access'>

--- a/themes/sis/templates/islandora-video.tpl.php
+++ b/themes/sis/templates/islandora-video.tpl.php
@@ -21,6 +21,13 @@
 
 <div class="islandora-video-object islandora" vocab="http://schema.org/" prefix="dcterms: http://purl.org/dc/terms/" typeof="VideoObject">
   <div class="islandora-video-content-wrapper clearfix">
+    <div class="IIIF" style="display: block;">
+      <?php $transformed_pid = str_replace(":", "/", $object->id); ?>
+      <?php $assemble_uri = 'http://' . getenv('HTTP_HOST') . '/assemble/manifest/' . $transformed_pid . '?update=1'; ?>
+      <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
+      <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
+      <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
+    </div>
     <?php if ($islandora_content): ?>
       <div class="islandora-video-content">
         <?php if (isset($object['MP4']) && !islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['MP4'])): ?><p>This video is restricted to campus only.</p><?php endif; ?>

--- a/themes/sis/templates/islandora-video.tpl.php
+++ b/themes/sis/templates/islandora-video.tpl.php
@@ -24,9 +24,9 @@
     <div class="IIIF" style="display: block;">
       <?php $transformed_pid = str_replace(":", "/", $object->id); ?>
       <?php $assemble_uri = 'http://' . getenv('HTTP_HOST') . '/assemble/manifest/' . $transformed_pid . '?update=1'; ?>
-      <?php print '<a href="' . $assemble_uri . '" ><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
-      <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
-      <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" ><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
+      <?php print '<a href="' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://iiif.io/assets/images/logos/logo-sm.png" alt="View IIIF Manifest" title="View IIIF Manifest" /></a>'; ?>
+      <?php print '<a href="https://uv-v3.netlify.app/#?c=&m=&s=&cv=&manifest=' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_uv.png" alt="Open in Universal Viewer" title="Open in Universal Viewer"/></a>'; ?>
+      <?php print '<a href="https://projectmirador.org/embed/?iiif-content=' . $assemble_uri . '" target="_blank"><img style="max-width:2rem" src="https://www.qdl.qa/sites/all/themes/QDLTheme/css/img/logo_mirador.png" alt="Open in Mirador" title="Open in Mirador"/></a>'; ?>
     </div>
     <?php if ($islandora_content): ?>
       <div class="islandora-video-content">


### PR DESCRIPTION
# What Does This Do

Adds IIIF icons to Islandora 7 for objects that are: basic images, large images, books, videos, or audio objects.

The icons allow you to:

* View the manifest
* Open in UV
* Open in Mirador

# How Do I Test

Checkout locally or somewhere with these types and see if you see icons like this:

![image](https://user-images.githubusercontent.com/2692416/173863296-e8c5f05e-0b02-4b8c-bc2e-9690b96c57e9.png)

# Why Are You Doing This Now

I'm doing a presentation tomorrow on IIIF and our repository, and I feel strongly that this work is prerequisite.

# Any big differences between template types

The biggest difference is that books should not regenerate but instead pull directly from cache.